### PR TITLE
pillow support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ def check_dependencies():
       print "    !!! Python Glade ............. ", _("Not found")
       required_found = False
   try:
-    import Image
+    from PIL import Image
     print "    Python Imaging Library ....... OK"
   except ImportError:
     print "    !!! Python Imaging Library ... ", _("Not found")

--- a/src/wallpapoz
+++ b/src/wallpapoz
@@ -35,7 +35,7 @@ import os
 import sys
 import stat
 import gettext
-import Image
+from PIL import Image
 
 try:
     import gnome


### PR DESCRIPTION
Hey there! I tried to add consistent Pillow support, because I wasn't that easily able to install PIL without pillow. The following two changes would add full pillow support to your project. I don't understand the way it is supported now:
- setup.py
- src/wallpapoz

use Image, but
- src/wallpapoz_gui/wallpapoz_menu.py
- src/wallpapoz_gui/wallpapoz_menu_commands.py

use PIL.Image (the pillow package)..
Regards!
