### PR TITLE
Improve MATE detection

### DIFF
--- a/share/wallpapoz/lib/wallpapoz_system.py
+++ b/share/wallpapoz/lib/wallpapoz_system.py
@@ -58,7 +58,7 @@ class WallpapozSystem:
       self.window_manager = 'XFCE4'
     elif wm_name=='Fluxbox':
       self.window_manager = 'Fluxbox'
-    elif wm_name=='Marco':
+    elif wm_name=='Marco' or wm_name=='Metacity (Marco)':
       self.window_manager = 'MATE'
     elif wm_name=='Mutter (Muffin)':
       self.window_manager = 'CINNAMON'


### PR DESCRIPTION
wm_name on Linux Mint 17.1 MATE is 'Metacity (Marco)' and not 'Marco' so wallpapoz was not working